### PR TITLE
Created new To-Do Service Overview page for Assignment 6.1

### DIFF
--- a/docs/overviews/to-do-overview_RentsV.md
+++ b/docs/overviews/to-do-overview_RentsV.md
@@ -28,7 +28,7 @@ last_updated: "2025-10-24"
 # markdownlint-enable
 ---
 
-# To-Do Service API overview
+# To-Do Service API (RentsV)
 
 To-Do Service API is a mock REST API that simulates a to-do app.
 This app allows you to stay on top of your obligations. You can see, add, change, and delete tasks.

--- a/docs/overviews/to-do-overview_cae-west.md
+++ b/docs/overviews/to-do-overview_cae-west.md
@@ -1,0 +1,91 @@
+---
+# markdownlint-disable
+# vale  off
+layout: default
+# nav_order: 1
+parent: To-Do Service API
+# tags used by AI files
+description: Alternate overview topic
+tags:
+    - overview
+categories: 
+    - overview
+ai_relevance: high
+importance: 6
+prerequisites: []
+related_pages: []
+examples: []
+api_endpoints:
+version: "v1.0"
+last_updated: "2025-11-02"
+# vale  on
+# markdownlint-enable
+---
+
+# To-Do Service API (cae-west)
+
+Manage tasks effortlessly with a cloud-hosted to-do list API.
+
+The To-Do Service allows you to manage users and their tasks within a simple REST API.
+
+Whether you want to build a productivity app, integrate task management into your platform,
+or prototype a workflow tool, the To-Do Service API gives you the flexibility to help your users
+get stuff done.
+
+## What's an API?
+
+An app programming interface, or API, is a tool that allows different software applications to
+communicate with one another, share resources, and deliver information across digital services.
+
+## Key features
+
+- **Google cloud platform management** - No infrastructure to maintain
+- **RESTful API** - Standard HTTP methods for easy integration
+- **Task reminders** - Automated notifications for upcoming due dates
+- **Simple enrollment** - Quick user onboarding process
+
+## Get started
+
+Ready to build? [Start with the quickstart guide](../before-you-start-a-tutorial.md).
+
+## For new users
+
+New to the To-Do Service? Follow these steps to start managing tasks:
+
+1. [Before you start a tutorial](../before-you-start-a-tutorial.md) - Download programs
+    and configure your system.
+2. [Enroll a new user](../tutorials/enroll-a-new-user.md) - Enroll your first new user.
+3. [Add your first task](../tutorials/add-a-new-task.md) - Post your first new task.
+
+## Documentation
+
+### Tutorials
+
+Step-by-step guides for common tasks:
+
+- [Enroll a new user](../tutorials/enroll-a-new-user.md)
+- [Add a new task](../tutorials/add-a-new-task.md)
+- **Change the due date of a task**
+- **Remove a user**
+- **Delete a task**
+
+### Reference materials
+
+Detailed documentation for all endpoints and resources:
+
+- [User resource](../api/user.md)
+- [Task resource](../api/task.md)
+
+## Support and help
+
+### Need help?
+
+- **FAQs** - Get answers to common questions.
+- **Contact support** - Get help from the To-Do Service team.
+
+### Other resources
+
+- Base URL for local testing: `http://localhost:3000`
+- **API status** - Check service availability.
+- **Release notes** - Track API updates and changes.
+- [Site map](../sitemap.xml) - View the site map.


### PR DESCRIPTION
Created new To-Do Service Overview page for Assignment 6.1. Added a link to the new page in the current overview page.

Fixes issue #140 

## Contributor Checklist

Confirm and check the following before opening the pull request (Note: you can save this as a draft as you copmlete the checklist):

- [X] My code follows the project's style guides.
- [X] I have linted my code locally and there are no new errors.
- [X] I have checked for Vale errors and there are no new errors.
- [X] I have deployed this feature branch to the GitHub Pages server for review.
- [X] I have personally verified my changes on the GitHub Pages deployment.
- [X] I have tested all new links that I've added.
- [X] I have updated the documentation to reflect my changes (if applicable).
- [X] I have added tests to cover my changes (if applicable).
- [X] I have added the correct assignment label for this change.

## What does this PR do?

This PR updates the overview page for the To-Do Service and includes a link to it in the original overview page.

## How should this be tested?

Ensure that the revised overview page is visible from the original version.

## Notes for Reviewers

None

## Exceptions to Checklist

N/A
