### PR TITLE
Created a new reference page for patching a task by ID for assignment 6.3

### DIFF
--- a/docs/api/patch-task-by-id.md
+++ b/docs/api/patch-task-by-id.md
@@ -1,0 +1,180 @@
+---
+# markdownlint-disable
+# vale  off
+layout: default
+# nav_order: 1
+parent: task resource
+# tags used by AI files
+description: PATCH method reference topic for task resource
+tags:
+    - overview
+categories: 
+    - overview
+ai_relevance: high
+importance: 6
+prerequisites: []
+related_pages: []
+examples: []
+api_endpoints:
+version: "v1.0"
+last_updated: "2025-11-14"
+# vale  on
+# markdownlint-enable
+---
+
+# Update a task by ID
+
+This operation updates or patches one or more properties of an existing task by ID.
+
+---
+
+## Endpoint structure
+
+```bash
+PATCH /tasks/{id}
+```
+
+---
+
+## Path parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | integer | Yes | The unique identifier of the task to update |
+
+---
+
+## Request headers
+
+| Header | Value | Required |
+|--------|-------|----------|
+| `Content-Type` | `application/json` | Yes |
+
+---
+
+## Request body
+
+Include only the properties you want to update. All fields are optional.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `userId` | integer | The ID of the user who owns this task |
+| `title` | string | Short description of the task |
+| `description` | string | Detailed description of the task |
+| `dueDate` | string | When the task is due |
+| `warning` | integer | Minutes before due date to send reminder |
+
+---
+
+## Postman request
+
+1. Set the request method to `PATCH`
+2. Enter the URL: `http://localhost:3000/tasks/1`
+   - Replace `1` with the ID of the task you want to update
+3. Go to the **Headers** tab and add:
+   - `Content-Type: application/json`
+4. Go to the **Body** tab:
+   - Select **raw**
+   - Choose **JSON** from the dropdown
+   - Enter your request body
+5. Click **Send**
+
+---
+
+## Example: Update due date
+
+**Request:**
+
+```bash
+PATCH http://localhost:3000/tasks/1
+Content-Type: application/json
+```
+
+**Body:**
+
+```json
+{
+  "dueDate": "2026-02-20T17:00:00-05:00"
+}
+```
+
+**Response - 200 OK:**
+
+```json
+{
+  "userId": 1,
+  "title": "Grocery shopping",
+  "description": "eggs, bacon, gummy bears",
+  "dueDate": "2026-02-20T17:00:00-05:00",
+  "warning": 10,
+  "id": 1
+}
+```
+
+---
+
+## More request buffer examples
+
+### Update title and description
+
+```json
+{
+  "title": "Weekly grocery shopping",
+  "description": "eggs, bacon, gummy bears, milk, bread"
+}
+```
+
+### Set reminder to 24 hours before due date
+
+```json
+{
+  "warning": 1440
+}
+```
+
+### Update more than one property at once
+
+```json
+{
+  "title": "Annual vet appointment",
+  "description": "Annual vaccinations and checkup",
+  "dueDate": "2026-02-20T17:00:00-05:00",
+  "warning": 2880
+}
+```
+
+---
+
+## Response
+
+Returns the complete updated task object with all properties.
+
+**Success:** `200 OK`
+
+**Response body includes:**
+
+- `id` - Task identifier - unchanged
+- `userId` - User who owns the task
+- `title` - Task title
+- `description` - Task description
+- `dueDate` - When the task is due
+- `warning` - Reminder timing in minutes
+
+---
+
+## Error responses
+
+| Status Code | Description |
+|-------------|-------------|
+| `400 Bad Request` | Invalid request body or parameter format |
+| `404 Not Found` | Task with the specified ID doesn't exist |
+| `500 Server Error` | Unexpected server error occurred |
+
+---
+
+## Related topics
+
+- [Get a user by ID](./users-get-user-by-id.md) - Retrieve details for a specific user
+- [Add a new task](../tutorials/add-a-new-task.md) - Add a new task to the service
+- [Enroll a new user](../tutorials/enroll-a-new-user.md) - Add a new user to the service
+- [Get all users](./users-get-all-users.md) - Retrieve all users in the service

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ After your system is ready, these tutorials show you how to perform common tasks
 * [Enroll a new user](tutorials/enroll-a-new-user.md)
 * [Add a new task](tutorials/add-a-new-task.md)
 * [Find a user by first name](tutorials/find-user-by-first-name.md)
+* [Update a task by ID](api/patch-task-by-id.md)
 * [Change the due-date of a task _(coming soon)_](#tutorials)
 * [Delete a task _(coming soon)_](#tutorials)
 


### PR DESCRIPTION
Created a new reference page for patching a task by ID. 

Updated the overview page with a link to the new reference page.

Fixes issue #173 

## Contributor Checklist

Confirm and check the following before opening the pull request (Note: you can save this as a draft as you complete the checklist):

- [X] My code follows the project's style guides.
- [X] I have linted my code locally and there are no new errors.
- [X] I have checked for Vale errors and there are no new errors.
- [X] I have deployed this feature branch to the GitHub Pages server for review.
- [X] I have personally verified my changes on the GitHub Pages deployment.
- [X] I have tested all new links that I've added.
- [X] I have updated the documentation to reflect my changes (if applicable).
- [X] I have added tests to cover my changes (if applicable).
- [X] I have added the correct assignment label for this change.

## What does this PR do?

This PR adds a new reference page to the To-Do Service on updating, or patching, tasks based on ID. It also updates the overview page with a link to the new reference page.

## How should this be tested?

Ensure the new documentation accurately reflects the ability to use the PATCH /tasks/{taskId} operation in the To-Do Service.

Ensure the overview page is correctly updated with the link to the new reference page.

## Notes for Reviewers

None

## Exceptions to Checklist

N/A
