### PR TITLE
Create reference topic about the GET /users?last_name= operation

### DIFF
--- a/docs/api/users-get-users-by-last-name.md
+++ b/docs/api/users-get-users-by-last-name.md
@@ -1,0 +1,119 @@
+---
+# markdownlint-disable
+# vale  off
+layout: default
+parent: user resource
+nav_order: 2
+# tags used by AI files
+description: GET the `user` resource with the lastName field
+tags:
+    - api
+categories:
+    - api-reference
+ai_relevance: high
+importance: 7
+prerequisites: 
+    - /api/user
+related_pages: []
+examples: []
+api_endpoints: 
+    - GET users?last_name=
+version: "v1.0"
+last_updated: "2025-10-26"
+# vale  on
+# markdownlint-enable
+---
+
+# Get a user by last name
+
+Returns an array of users that share the same `lastName` parameter, if they exist.
+
+## Method
+
+`GET`
+
+## URL
+
+```shell
+{server_url}/users?last_name=
+```
+
+## Parameters
+
+|Parameter name|Type|Description|
+|--------------|------|------------|
+|`last_name`|string|The last name of the users to return|
+
+## Request headers
+
+None
+
+## Request body
+
+None
+
+## Example request with matching users
+
+```shell
+curl -X GET "{server_url}/users?last_name=Smith"
+```
+
+## Return body
+
+```json
+[
+    {
+        "lastName": "Smith",
+        "firstName": "Ferdinand",
+        "email": "f.smith@example.com",
+        "id": 1
+    },
+
+    {
+        "lastName": "Smith",
+        "firstName": "Jacqueline",
+        "email": "jaq.smith@example.com",
+        "id": 5
+    }
+]
+```
+
+**Status:** 200 OK
+
+## Return body properties
+
+|Property name|Type|Description|
+|-------------|-----------|-----------|
+|`lastName`|string|The last name of the user resource|
+|`firstName`|string|The first name of the user resource|
+|`email`|string|The email address of the user resource|
+|`id`|number|The user's unique record ID|
+
+## Example request with no matching users
+
+**Request:**
+
+```shell
+curl "{server_url}/users?last_name=doesNotExist"
+```
+
+**Response:**
+
+```json
+[]
+```
+
+**Status:** 200 OK
+
+## Return status
+
+|Status value|Return status|Description|
+|-------------|-----------|-----------|
+|200|Success|Requested data returned successfully; empty array `[]` if no matches|
+|400|Error|Bad request; missing or invalid `last_name` parameter|
+|ECONNREFUSED|N/A|Service is offline; start service, try again|
+
+## Related topics
+
+- [Get all users](../api/users-get-all-users.md)
+- [Get a user by ID](../api/users-get-user-by-id.md)


### PR DESCRIPTION
## Contributor Checklist

- [x] My code follows the project's style guides.
- [x] I have linted my code locally and there are no new errors.
- [x] I have checked for Vale errors and there are no new errors.
- [x] I have deployed this feature branch to the GitHub Pages server for review.
- [x] I have personally verified my changes on the GitHub Pages deployment.
- [x] I have tested all new links that I've added.
- [x] I have updated the documentation to reflect my changes (if applicable).
- [ ] I have added tests to cover my changes (if applicable).
- [x] I have added the correct assignment label for this change.

## What does this PR do?

As assigned by [Issue 169](https://github.com/UWC2-APIDOC/to-do-service-au25/issues/169): "Create a new markdown file in the docs\api directory about the GET /users?last_name= operation and create the topic as described in assignment 6.3. Give the new file a file name related to the topic, but not too long."

## How should this be tested?

No special test procedures required.

## Notes for Reviewers

The following question was answered in the code review comments of https://github.com/UWC2-APIDOC/to-do-service-au25/pull/179 in which we’re advised to “use local links to topics in the documentation, here and elsewhere.” I’m leaving the question here for future reference.

On Line 119, my link to the the "Get a user by ID" resource topic appears to work in spite of not having the markdown `.md` - is there a stylistic preference either way?

## Exceptions to Checklist

This assignment doesn’t require any new tests.